### PR TITLE
Update fdmi_show.py

### DIFF
--- a/pyfos/utils/fdmi/fdmi_show.py
+++ b/pyfos/utils/fdmi/fdmi_show.py
@@ -16,7 +16,7 @@
 
 """
 
-:mod:`fdmi_show` - PyFOS util to show FMDI entries.
+:mod:`fdmi_show` - PyFOS util to show FDMI entries.
 ***********************************************************************************
 The :mod:`fdmi_show` supports 'fdmishow' CLI use case.
 

--- a/pyfos/utils/supportftp/supportftp_modify.py
+++ b/pyfos/utils/supportftp/supportftp_modify.py
@@ -187,6 +187,8 @@ def main(argv):
                 skipattributes += ","
             skipattributes += "protocol"
         if supportftp_obj.peek_port() is not None:
+            if len(skipattributes) > 0:
+                skipattributes += ","
             skipattributes += "port"
         if supportftp_obj.peek_connectivity_check_interval() \
            is not None:


### PR DESCRIPTION
typo line 19
:mod:`fdmi_show` - PyFOS util to show FMDI entries.

:mod:`fdmi_show` - PyFOS util to show FDMI entries.